### PR TITLE
Validation of SNS messages of type: Notification should not accept Token attribute

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,16 @@ var url = require('url'),
         'SigningCertURL',
         'SignatureVersion'
     ],
-    signableKeys = [
+    signableKeysForNotification = [
+        'Message',
+        'MessageId',
+        'Subject',
+        'SubscribeURL',
+        'Timestamp',
+        'TopicArn',
+        'Type'
+    ],
+    signableKeysForSubscription = [
         'Message',
         'MessageId',
         'Subject',
@@ -93,6 +102,13 @@ var validateSignature = function (message, cb, encoding) {
         cb(new Error('The signature version '
             + message['SignatureVersion'] + ' is not supported.'));
         return;
+    }
+
+    var signableKeys = [];
+    if (message.Type === 'SubscriptionConfirmation') {
+        signableKeys = signableKeysForSubscription.slice(0);
+    } else {
+        signableKeys = signableKeysForNotification.slice(0);
     }
 
     var verifier = crypto.createVerify('RSA-SHA1');

--- a/test/validator.js
+++ b/test/validator.js
@@ -5,7 +5,7 @@ var chai = require('chai'),
     pem = require('pem'),
     _ = require('underscore'),
     MessageValidator = rewire('../index.js'),
-    signableKeys = MessageValidator.__get__('signableKeys'),
+    signableKeysForSubscription = MessageValidator.__get__('signableKeysForSubscription'),
     invalidMessage = {
         foo: 'bar',
         fizz: 'buzz'
@@ -53,10 +53,10 @@ describe('Message Validator', function () {
             for (var i = 0; i < validMessages.length; i++) {
                 var signer = crypto.createSign('RSA-SHA1');
 
-                for (var j = 0; j < signableKeys.length; j++) {
-                    if (signableKeys[j] in validMessages[i]) {
-                        signer.update(signableKeys[j] + "\n"
-                            + validMessages[i][signableKeys[j]] + "\n");
+                for (var j = 0; j < signableKeysForSubscription.length; j++) {
+                    if (signableKeysForSubscription[j] in validMessages[i]) {
+                        signer.update(signableKeysForSubscription[j] + "\n"
+                            + validMessages[i][signableKeysForSubscription[j]] + "\n");
                     }
                 }
 
@@ -208,10 +208,10 @@ describe('Message Validator', function () {
                 for (var i = 0; i < validMessages.length; i++) {
                     var signer = crypto.createSign('RSA-SHA1');
 
-                    for (var j = 0; j < signableKeys.length; j++) {
-                        if (signableKeys[j] in validMessages[i]) {
-                            signer.update(signableKeys[j] + "\n"
-                                + validMessages[i][signableKeys[j]] + "\n", 'utf8');
+                    for (var j = 0; j < signableKeysForSubscription.length; j++) {
+                        if (signableKeysForSubscription[j] in validMessages[i]) {
+                            signer.update(signableKeysForSubscription[j] + "\n"
+                                + validMessages[i][signableKeysForSubscription[j]] + "\n", 'utf8');
                         }
                     }
 


### PR DESCRIPTION
As stated at http://docs.aws.amazon.com/sns/latest/dg/SendMessageToHttp.verify.signature.html
### Notification messages must contain:

``` Message
MessageId
Subject (if included in the message)
Timestamp
TopicArn
Type
```
### SubscriptionConfirmation and UnsubscribeConfirmation messages must contain:

```
Message
MessageId
SubscribeURL
Timestamp
Token
TopicArn
Type
```
