### PR TITLE
Handle crypto.verify exceptions

### DIFF
--- a/index.js
+++ b/index.js
@@ -125,10 +125,14 @@ var validateSignature = function (message, cb, encoding) {
             return;
         }
 
-        if (verifier.verify(certificate, message['Signature'], 'base64')) {
-            cb(null, message);
-        } else {
-            cb(new Error('The message signature is invalid.'));
+        try {
+            if (verifier.verify(certificate, message['Signature'], 'base64')) {
+                cb(null, message);
+            } else {
+                cb(new Error('The message signature is invalid.'));
+            }
+        } catch (err) {
+            cb(err);
         }
     });
 };


### PR DESCRIPTION
Calling the _validate()_ function with [this example _SubscriptionConfirmation_ message](http://docs.aws.amazon.com/sns/latest/dg/SendMessageToHttp.html#SendMessageToHttp.prepare) results in an application crash because of an unhandled exception:

```
Error: PEM_read_bio_PUBKEY failed
  at Error (native)
  at Verify.verify (crypto.js:304:23)
  at /microservice/node_modules/sns-validator/index.js:129:22
  at IncomingMessage.<anonymous> (/microservice/node_modules/sns-validator/index.js:96:1)
  at emitNone (events.js:91:20)
  at IncomingMessage.emit (events.js:185:7)
  at endReadableNT (_stream_readable.js:934:12)
  at _combinedTickCallback (internal/process/next_tick.js:74:11)
  at process._tickDomainCallback (internal/process/next_tick.js:122:9)
```
