### PR TITLE
Better handling of invalide certificate file

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,6 +86,11 @@ var getCertificate = function (certUrl, cb) {
 
     https.get(certUrl, function (res) {
         var chunks = [];
+
+        if(res.statusCode !== 200){
+            return cb(new Error('Certificate could not be retrieved'));
+        }
+
         res
             .on('data', function (data) {
                 chunks.push(data.toString());
@@ -124,11 +129,14 @@ var validateSignature = function (message, cb, encoding) {
             cb(err);
             return;
         }
-
-        if (verifier.verify(certificate, message['Signature'], 'base64')) {
-            cb(null, message);
-        } else {
-            cb(new Error('The message signature is invalid.'));
+        try {
+            if (verifier.verify(certificate, message['Signature'], 'base64')) {
+                cb(null, message);
+            } else {
+                cb(new Error('The message signature is invalid.'));
+            }
+        } catch (e) {
+            cb(e);
         }
     });
 };


### PR DESCRIPTION
* handle non 200 response for certificate file download
* handle uncaught exception during signature verification

Discovered when used with example data from http://docs.aws.amazon.com/sns/latest/dg/SendMessageToHttp.html

I didn't expect it to work, but uncaught exception crashed the app, and I also noticed that response status of the SigningCertURL is not checked.

Both does not seem to be a valid behavior, despite should not often cause a trouble.