### PR TITLE
feat(lambda): Validate SNS signature in lambda

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 var url = require('url'),
     https = require('https'),
     crypto = require('crypto'),
+    isNil = require('lodash.isnil'),
     defaultEncoding = 'utf8',
     defaultHostPattern = /^sns\.[a-zA-Z0-9\-]{3,}\.amazonaws\.com(\.cn)?$/,
     certCache = {},
@@ -129,13 +130,14 @@ var validateSignature = function (message, cb, encoding) {
 
     var verifier = crypto.createVerify('RSA-SHA1');
     for (var i = 0; i < signableKeys.length; i++) {
-        if (signableKeys[i] in message) {
+        if (signableKeys[i] in message && !isNil(message[signableKeys[i]])) {
             verifier.update(signableKeys[i] + "\n"
                 + message[signableKeys[i]] + "\n", encoding);
         }
     }
 
-    getCertificate(message['SigningCertURL'], function (err, certificate) {
+    const certificateUrl = message.SigningCertURL || message.SigningCertUrl;
+    getCertificate(certificateUrl, function (err, certificate) {
         if (err) {
             cb(err);
             return;

--- a/index.js
+++ b/index.js
@@ -136,7 +136,7 @@ var validateSignature = function (message, cb, encoding) {
         }
     }
 
-    const certificateUrl = message.SigningCertURL || message.SigningCertUrl;
+    var certificateUrl = message.SigningCertURL || message.SigningCertUrl;
     getCertificate(certificateUrl, function (err, certificate) {
         if (err) {
             cb(err);

--- a/package.json
+++ b/package.json
@@ -26,5 +26,8 @@
     "SNS"
   ],
   "author": "Amazon Web Services",
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
+  "dependencies": {
+    "lodash.isnil": "^4.0.0"
+  }
 }


### PR DESCRIPTION
Related to #2 and #10 

- Remove nil fields in the event to prevent wrong string to sign build. `Subject` field is always added to the SNS message and set to `null` on lambda handling, leading to the unability to create the string to sign. 

- Looks at both SigningCertURL and SigningCertUrl for the certificate url (related to #10 )