### PR TITLE
Fix getCertificate call for `Url` suffix

### DIFF
--- a/index.js
+++ b/index.js
@@ -135,7 +135,7 @@ var validateSignature = function (message, cb, encoding) {
         }
     }
 
-    getCertificate(message['SigningCertURL'], function (err, certificate) {
+    getCertificate(message['SigningCertURL'] || message['SigningCertUrl'], function (err, certificate) {
         if (err) {
             cb(err);
             return;


### PR DESCRIPTION
Since the payload can either have a SigningCertURL or a SigningCertUrl key, the getCertificate call should take this into account. This PR fixes a problem I experienced when validating SNS payloads.