### PR TITLE
issues/21: Add support for agent

### DIFF
--- a/test/validator.js
+++ b/test/validator.js
@@ -84,7 +84,7 @@ describe('Message Validator', function () {
                     = signer.sign(certHash.serviceKey, 'base64');
             }
 
-            MessageValidator.__set__('getCertificate', function (url, cb) {
+            MessageValidator.__set__('getCertificate', function (url, httpOptions, cb) {
                 cb(null, certHash.certificate);
             });
             done();


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-js-sns-message-validator/issues/21
*Description of changes:*
Add optional constructor parameter httpOptions, that currently supports agent

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
