### PR TITLE
chore: replace deprecated String.prototype.substr()

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,7 +93,7 @@ var validateUrl = function (urlToValidate, hostPattern) {
     var parsed = url.parse(urlToValidate);
 
     return parsed.protocol === 'https:'
-        && parsed.path.substr(-4) === '.pem'
+        && parsed.path.slice(-4) === '.pem'
         && hostPattern.test(parsed.host);
 };
 


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
