### PR TITLE
Bump package version to 0.3.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sns-validator",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "A standalone validator for inbound SNS HTTP messages. No dependency on the AWS SDK for JavaScript.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
*Issue #, if available:*
Required for releasing https://github.com/aws/aws-js-sns-message-validator/pull/32

*Description of changes:*
Bumps package version to 0.3.5

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
